### PR TITLE
Ivy regex fix

### DIFF
--- a/config.el
+++ b/config.el
@@ -309,65 +309,7 @@ corresponding module"
         '((left-fringe . 10)
           (right-fringe . 10))))
 
-(defun jedi/split-string-keeping-separators (string regex)
-  "Helper function to split an input string into segments using a regex for
-separators. Unlike `split-string', the separators are returned as part of the
-resulting list."
-  (let ((case-fold-search nil)
-        (i 0)
-        (len (length string))
-        (list nil))
-    (while (and (< i len)
-                (string-match regex string i))
-      ; add anything between the current point and the beginning of the match
-      (when (< i (match-beginning 0))
-          (push (substring string i (match-beginning 0)) list))
-      ; add the match itself
-      (push (substring string (match-beginning 0) (match-end 0)) list)
-      (setq i (match-end 0)))
-
-    ;; add any remaining text after the last match
-    (if (< i len)
-        (push (substring string i len) list))
-    (nreverse list)))
-
-(defun jedi/ivy-regex (input)
-  "Function to turn a query supplied by ivy into the regex that
-we'll use to filter results. Works pretty much like
-`ivy--regex-ignore-order', except that it does a bit of
-pre-processing to allow using sequences of uppercase characters
-as initials.
-
-As an example, this means that \"PLHMain\" will match \"Page/Learn/Home/Main.elm\""
-  (let* (; tokenize the query using sequences of uppercase characters as separators
-         ; e.g.: "PLHMain" -> ("PLHM" "ain")
-         (parts (jedi/split-string-keeping-separators input "[[:upper:]]+"))
-         ; function that turns an uppercase string into a pattern that
-         ; interprets each char as an initial by intercalating a ".*" to match
-         ; any intermediate characters followed by "\\b" (word boundary).
-         ; e.g.: "ABC" -> "A.*\\bB.*\\b"
-         (fun (lambda (part)
-                (if (string-equal (upcase part) part)
-                    (let*
-                        ((chars (split-string part "" t "[[:blank]]"))
-                         (joiners (make-list (length chars) ".*\\b")))
-                      (apply 'concat (butlast (-interleave chars joiners))))
-                  part)
-                ))
-         ; applies the function above to the sequence of tokens, so sequences of
-         ; uppercase chars are interpreted as initials leaving the other
-         ; segments untouched.
-         ; e.g.: ("PLHM" "ain") -> ("P.*\\bL.*\\bH.*\\bM" "ain")
-         (transformed-parts (seq-map fun parts))
-         ; joins the transformed segments to build a new query
-         ; e.g.: ("P.*\\bL.*\\bH.*\\bM" "ain") -> "P.*\\bL.*\\bH.*\\bMain"
-         (query (string-join transformed-parts "")))
-    ; after pre-processing the query, call `ivy--regex-ignore-order' which
-    ; basically:
-    ;   - splits the input at whitespaces to get a list of subqueries
-    ;   - runs each of those as a separate filter
-    (ivy--regex-ignore-order query)))
-
+(load-file (concat doom-user-dir "ivy-regex.el"))
 (ivy--alist-set 'ivy-re-builders-alist t 'jedi/ivy-regex)
 
 ;; ----------------------------------------------------------------------------

--- a/ivy-regex-tests.el
+++ b/ivy-regex-tests.el
@@ -18,3 +18,6 @@
 
 ;; sequences of uppercase letters are interpreted as as "initials"
 (jedi/ivy-regex--check "PLH" "Page/Learn/Home/Main.elm")
+
+;; sequences of uppercase chars also match as a literal
+(jedi/ivy-regex--check "PLH" "PLH.txt")

--- a/ivy-regex-tests.el
+++ b/ivy-regex-tests.el
@@ -1,0 +1,20 @@
+; use eval-buffer to run tests!
+(defun jedi/ivy-regex--check (query candidate)
+  (let ((regex (car (car (jedi/ivy-regex query)))))
+    (cl-assert (string-match
+                regex
+                candidate)
+               nil
+               "%s did not match candidate: %s"
+               query
+               candidate
+               )))
+
+;; matching literals
+(jedi/ivy-regex--check "foo" "foo")
+
+;; splits query into segments that filter independently and disregarding order
+(jedi/ivy-regex--check "foo bar" "barfoo")
+
+;; sequences of uppercase letters are interpreted as as "initials"
+(jedi/ivy-regex--check "PLH" "Page/Learn/Home/Main.elm")

--- a/ivy-regex.el
+++ b/ivy-regex.el
@@ -22,7 +22,7 @@ resulting list."
         (push (substring string i len) list))
     (nreverse list)))
 
-(defun jedi/ivy-regex--part-to-initials (part)
+(defun jedi/ivy-regex--part-to-regex (part)
   "function that turns an uppercase string into a pattern that
 interprets each char as an initial by intercalating a \".*\" to
 match any intermediate characters followed by \"\\b\" (word
@@ -33,7 +33,6 @@ boundary). e.g.: \"ABC\" -> \"A.*\\bB.*\\b\""
            (joiners (make-list (length chars) ".*\\b")))
         (apply 'concat (butlast (-interleave chars joiners))))
     part))
-
 
 (defun jedi/ivy-regex (input)
   "Function to turn a query supplied by ivy into the regex that
@@ -46,11 +45,9 @@ As an example, this means that \"PLHMain\" will match \"Page/Learn/Home/Main.elm
   (let* (; tokenize the query using sequences of uppercase characters as separators
          ; e.g.: "PLHMain" -> ("PLHM" "ain")
          (parts (jedi/ivy-regex--split-string-keeping-separators input "[[:upper:]]+"))
-         ; applies the function above to the sequence of tokens, so sequences of
-         ; uppercase chars are interpreted as initials leaving the other
-         ; segments untouched.
+         ;; turns each part into a regex
          ; e.g.: ("PLHM" "ain") -> ("P.*\\bL.*\\bH.*\\bM" "ain")
-         (transformed-parts (seq-map #'jedi/ivy-regex--part-to-initials parts))
+         (transformed-parts (seq-map #'jedi/ivy-regex--part-to-regex parts))
          ; joins the transformed segments to build a new query
          ; e.g.: ("P.*\\bL.*\\bH.*\\bM" "ain") -> "P.*\\bL.*\\bH.*\\bMain"
          (query (string-join transformed-parts "")))

--- a/ivy-regex.el
+++ b/ivy-regex.el
@@ -28,11 +28,14 @@ interprets each char as an initial by intercalating a \".*\" to
 match any intermediate characters followed by \"\\b\" (word
 boundary). e.g.: \"ABC\" -> \"A.*\\bB.*\\b\""
   (if (string-equal (upcase part) part)
-      (let*
-          ((chars (split-string part "" t "[[:blank:]]*"))
-           (joiners (make-list (length chars) ".*\\b")))
-        (apply 'concat (butlast (-interleave chars joiners))))
+      (jedi/ivy-regex--uppercase-sequence-to-regex part)
     part))
+
+(defun jedi/ivy-regex--uppercase-sequence-to-regex (part)
+  (let*
+      ((chars (split-string part "" t "[[:blank:]]*"))
+       (joiners (make-list (length chars) ".*\\b")))
+    (apply 'concat (butlast (-interleave chars joiners)))))
 
 (defun jedi/ivy-regex (input)
   "Function to turn a query supplied by ivy into the regex that

--- a/ivy-regex.el
+++ b/ivy-regex.el
@@ -1,0 +1,60 @@
+;;; ivy-regex.el -*- lexical-binding: t; -*-
+
+(defun jedi/split-string-keeping-separators (string regex)
+  "Helper function to split an input string into segments using a regex for
+separators. Unlike `split-string', the separators are returned as part of the
+resulting list."
+  (let ((case-fold-search nil)
+        (i 0)
+        (len (length string))
+        (list nil))
+    (while (and (< i len)
+                (string-match regex string i))
+      ; add anything between the current point and the beginning of the match
+      (when (< i (match-beginning 0))
+          (push (substring string i (match-beginning 0)) list))
+      ; add the match itself
+      (push (substring string (match-beginning 0) (match-end 0)) list)
+      (setq i (match-end 0)))
+
+    ;; add any remaining text after the last match
+    (if (< i len)
+        (push (substring string i len) list))
+    (nreverse list)))
+
+(defun jedi/ivy-regex (input)
+  "Function to turn a query supplied by ivy into the regex that
+we'll use to filter results. Works pretty much like
+`ivy--regex-ignore-order', except that it does a bit of
+pre-processing to allow using sequences of uppercase characters
+as initials.
+
+As an example, this means that \"PLHMain\" will match \"Page/Learn/Home/Main.elm\""
+  (let* (; tokenize the query using sequences of uppercase characters as separators
+         ; e.g.: "PLHMain" -> ("PLHM" "ain")
+         (parts (jedi/split-string-keeping-separators input "[[:upper:]]+"))
+         ; function that turns an uppercase string into a pattern that
+         ; interprets each char as an initial by intercalating a ".*" to match
+         ; any intermediate characters followed by "\\b" (word boundary).
+         ; e.g.: "ABC" -> "A.*\\bB.*\\b"
+         (fun (lambda (part)
+                (if (string-equal (upcase part) part)
+                    (let*
+                        ((chars (split-string part "" t "[[:blank:]]*"))
+                         (joiners (make-list (length chars) ".*\\b")))
+                      (apply 'concat (butlast (-interleave chars joiners))))
+                  part)
+                ))
+         ; applies the function above to the sequence of tokens, so sequences of
+         ; uppercase chars are interpreted as initials leaving the other
+         ; segments untouched.
+         ; e.g.: ("PLHM" "ain") -> ("P.*\\bL.*\\bH.*\\bM" "ain")
+         (transformed-parts (seq-map fun parts))
+         ; joins the transformed segments to build a new query
+         ; e.g.: ("P.*\\bL.*\\bH.*\\bM" "ain") -> "P.*\\bL.*\\bH.*\\bMain"
+         (query (string-join transformed-parts "")))
+    ; after pre-processing the query, call `ivy--regex-ignore-order' which
+    ; basically:
+    ;   - splits the input at whitespaces to get a list of subqueries
+    ;   - runs each of those as a separate filter
+    (ivy--regex-ignore-order query)))

--- a/ivy-regex.el
+++ b/ivy-regex.el
@@ -1,6 +1,6 @@
 ;;; ivy-regex.el -*- lexical-binding: t; -*-
 
-(defun jedi/split-string-keeping-separators (string regex)
+(defun jedi/ivy-regex--split-string-keeping-separators (string regex)
   "Helper function to split an input string into segments using a regex for
 separators. Unlike `split-string', the separators are returned as part of the
 resulting list."
@@ -32,7 +32,7 @@ as initials.
 As an example, this means that \"PLHMain\" will match \"Page/Learn/Home/Main.elm\""
   (let* (; tokenize the query using sequences of uppercase characters as separators
          ; e.g.: "PLHMain" -> ("PLHM" "ain")
-         (parts (jedi/split-string-keeping-separators input "[[:upper:]]+"))
+         (parts (jedi/ivy-regex--split-string-keeping-separators input "[[:upper:]]+"))
          ; function that turns an uppercase string into a pattern that
          ; interprets each char as an initial by intercalating a ".*" to match
          ; any intermediate characters followed by "\\b" (word boundary).


### PR DESCRIPTION
Fixes my the regex builder for ivy matching to account for the last case:

```emacs-lisp
;; matching literals
(jedi/ivy-regex--check "foo" "foo")

;; splits query into segments that filter independently and disregarding order
(jedi/ivy-regex--check "foo bar" "barfoo")

;; sequences of uppercase letters are interpreted as as "initials"
(jedi/ivy-regex--check "PLH" "Page/Learn/Home/Main.elm")

;; sequences of uppercase chars also match as a literal
(jedi/ivy-regex--check "PLH" "PLH.txt")
```